### PR TITLE
Disable host_key_checking for using in jenkins slaves

### DIFF
--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 inventory=./hosts
 accept_hostkey=true
+host_key_checking=false


### PR DESCRIPTION
When vms are reprovisioned and used in Jenkins slaves, the host key is changed and it causes issues. This PR disables the host key checking in ansible configuration.