### PR TITLE
Adding new features to add the entry on /etc/hosts

### DIFF
--- a/CentOS5/startup.sh
+++ b/CentOS5/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"

--- a/CentOS6/startup.sh
+++ b/CentOS6/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"

--- a/CentOS7/startup.sh
+++ b/CentOS7/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"
@@ -42,3 +48,4 @@ if [ -z "$KILL" ]; then
     goferd -f
     tail -f /var/log/rhsm/rhsm.log
 fi
+

--- a/OpenSuse/startup.sh
+++ b/OpenSuse/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Accepted Arguments
  * KILL - If this is not passed, then the container will be kept alive and goferd running.
  * ORG - Name of the Organization to use.
  * SATHOST(Required) - Hostname of the Satellite (not url).
+ * LOCAL - IP Address of the Satellite Server when we are not able to retrieve the correct info via DNS.
 
 Note
 ----
@@ -34,6 +35,8 @@ If you want to be able to use katello-agent, you must mount your /dev/log to the
 Examples
 --------
 ```docker run -e "SATHOST=my.host.domain.com" jacobcallahan/content-host-d:5```
+
+```docker run -e "SATHOST=my.host.domain.com" -e "LOCAL=192.168.0.10" jacobcallahan/content-host-d:5```
 
 ```docker run -e "SATHOST=my.host.domain.com" -e "ENV=Dev" -e "AUTH=username/password" jacobcallahan/content-host-d:6```
 

--- a/RHEL6-Puppet/startup.sh
+++ b/RHEL6-Puppet/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"

--- a/RHEL6/startup.sh
+++ b/RHEL6/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"

--- a/RHEL7-Guest/startup.sh
+++ b/RHEL7-Guest/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add custom facts to fake being a virt-who guest
 if [ -n "$UUID" ]; then
     echo "Adding guest config with UUID: $UUID."

--- a/RHEL7-Puppet/startup.sh
+++ b/RHEL7-Puppet/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"

--- a/RHEL7/startup.sh
+++ b/RHEL7/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"

--- a/RHEL72/startup.sh
+++ b/RHEL72/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"

--- a/SLES11/startup.sh
+++ b/SLES11/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"

--- a/SLES12/startup.sh
+++ b/SLES12/startup.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Adding the local entry on /etc/hosts
+if [ -n "$LOCAL" ]; then
+    echo "Adding entry '$LOCAL $SATHOST' on /etc/hosts"
+    echo "$LOCAL $SATHOST" >>/etc/hosts 
+fi
+
 # Add the Satellite's cert
 if [ -n "$SATHOST" ]; then
     echo "Adding satellite certificate http://$SATHOST/pub/katello-ca-consumer-latest.noarch.rpm"


### PR DESCRIPTION
Hello all

Currently, we expect to our DNS be able to resolve all information `Sat server name` btw on my env, I'm just using the entry on `/etc/hosts`. That said, this feature enables us to add the entry on `/etc/hosts` and then the Content Host will be able to register and proceed without issues.

Thank you
Waldirio