### PR TITLE
Adding shell to script

### DIFF
--- a/flood.py
+++ b/flood.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 import argparse, json, os, sys, time, uuid
 from collections import deque
 import docker


### PR DESCRIPTION
negates the need to run 'python flood.py"