### PR TITLE
Add container network mode option to flood.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+flood.log
+container.log

--- a/flood.py
+++ b/flood.py
@@ -44,7 +44,7 @@ def rm_container(client, containers, reason="Success"):
     logging.info('Done with {0}: {1}'.format(del_container['name'], reason))
 
 
-def host_flood(count, tag, name, env_vars, limit, image, criteria, rhsm_log_dir):
+def host_flood(count, tag, name, env_vars, limit, image, network_mode, criteria, rhsm_log_dir):
     client = docker.Client(version='1.22')  # docker.from_env()
     num = 1
     containers = deque()
@@ -79,7 +79,7 @@ def host_flood(count, tag, name, env_vars, limit, image, criteria, rhsm_log_dir)
             if binds.get(local_file or None):
                 del binds[local_file]
             containers.append({'container': container, 'name': hostname})
-            client.start(container=container)
+            client.start(container=container, network_mode=network_mode)
             logging.info('Created: {0}'.format(hostname))
             num += 1
 
@@ -219,6 +219,13 @@ if __name__ == '__main__':
         help="The image tag you want the container based on. ch-d:<tag>",
     )
     parser.add_argument(
+        "-m",
+        "--network-mode",
+        type=str,
+        default=None,
+        help="Container network mode to use.",
+    )
+    parser.add_argument(
         "-s",
         "--satellite",
         type=str,
@@ -336,6 +343,7 @@ if __name__ == '__main__':
             env_vars,
             args.limit,
             args.image,
+            args.network_mode,
             criteria,
             args.rhsm_log_dir,
         )

--- a/playbooks/chd-run.yaml
+++ b/playbooks/chd-run.yaml
@@ -10,6 +10,7 @@
     EXIT_CRITERIA: changeme
     RHSM_LOG_DIR: rhsm_logs
     CONTAINER_TAG: rhel7
+    NETWORK_MODE: changeme
     LIMIT: 100
   tasks:
   - name: Run flood.py command
@@ -22,6 +23,7 @@
           --exit-criteria {{ EXIT_CRITERIA }}
           --rhsm-log-dir {{ RHSM_LOG_DIR }}
           --tag {{ CONTAINER_TAG }}
+          --network-mode {{ NETWORK_MODE }}
           --limit {{ LIMIT }}
     args:
       chdir: /content-host-d/


### PR DESCRIPTION
This was handy for me when using flood.py on the same machine where I spun up a Katello box with libvirt.

Also adds flood.log and container.log to gitignore :)