### PR TITLE
Workaround for BZ#1958220

### DIFF
--- a/RHEL7/startup.sh
+++ b/RHEL7/startup.sh
@@ -39,6 +39,9 @@ else
     subscription-manager register --org="$ORG" --environment="Library" $AUTH
 fi
 
+# Workaround for BZ#1958220
+subscription-manager attach --auto
+
 # Install katello agent
 yum -y install katello-agent
 


### PR DESCRIPTION
Hello

We need `subscription-manager attach --auto`
as work around for
[Bug 1958220 - Registering a container to Sat6.8 fails to enable RHEL repos](https://bugzilla.redhat.com/show_bug.cgi?id=1958220)

Thank you