### PR TITLE
return workdir back to /root everywhere to be consistent

### DIFF
--- a/RHEL6/Dockerfile
+++ b/RHEL6/Dockerfile
@@ -15,6 +15,7 @@ ADD setup_scripts/* /tmp/setup_scripts/
 WORKDIR /tmp
 RUN chmod +x *.sh setup_scripts/*.sh || true
 RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
+WORKDIR /root
 
 EXPOSE 22
 

--- a/UBI7/Dockerfile
+++ b/UBI7/Dockerfile
@@ -15,6 +15,7 @@ ADD setup_scripts/* /tmp/setup_scripts/
 WORKDIR /tmp
 RUN chmod +x *.sh setup_scripts/*.sh
 RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
+WORKDIR /root
 
 EXPOSE 22
 

--- a/UBI8/Dockerfile
+++ b/UBI8/Dockerfile
@@ -15,6 +15,7 @@ ADD setup_scripts/* /tmp/setup_scripts/
 WORKDIR /tmp
 RUN chmod +x *.sh setup_scripts/*.sh
 RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
+WORKDIR /root
 
 EXPOSE 22
 

--- a/UBI9/Dockerfile
+++ b/UBI9/Dockerfile
@@ -15,6 +15,7 @@ ADD setup_scripts/* /tmp/setup_scripts/
 WORKDIR /tmp
 RUN chmod +x *.sh setup_scripts/*.sh
 RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
+WORKDIR /root
 
 EXPOSE 22
 


### PR DESCRIPTION
There are some reports (@ogajduse) of failing broker tests after my recent refactor of RHEL and UBI images, as the tests assume the workdir to be `/root` by default. Since the problem itself should be probably fixed in broker tests, I'm rather fixing it here as well to make the workdir consistent with the rest of the images.