### PR TITLE
Better way around subscription-manager container detection

### DIFF
--- a/OpenSuse/Dockerfile
+++ b/OpenSuse/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
 ADD startup.sh /tmp/
 ADD install-tools.sh /tmp/
 RUN chmod +x /tmp/startup.sh

--- a/RHEL6-Puppet/Dockerfile
+++ b/RHEL6-Puppet/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER https://github.com/jyejare
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.6/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 
 ADD startup.sh /tmp
 RUN chmod +x /tmp/startup.sh

--- a/RHEL6/Dockerfile
+++ b/RHEL6/Dockerfile
@@ -5,7 +5,7 @@ LABEL broker_compatible="True"
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.6/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 
 # add and process the external resources

--- a/RHEL7-Guest/Dockerfile
+++ b/RHEL7-Guest/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 ADD startup.sh /tmp/
 RUN chmod +x /tmp/startup.sh
 ADD hostname-3.13-3.el7.x86_64.rpm /tmp/

--- a/RHEL7-High-Traffic/Dockerfile
+++ b/RHEL7-High-Traffic/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 ADD startup.sh /tmp/
 RUN chmod +x /tmp/startup.sh

--- a/RHEL7-Puppet/Dockerfile
+++ b/RHEL7-Puppet/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root
 # RUN sleep .1 ; printf "%s\n" "dog8code" "dog8code" | passwd
 # RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 # RUN sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 ADD startup.sh /tmp/
 RUN chmod +x /tmp/startup.sh
 ADD hostname-3.13-3.el7.x86_64.rpm /tmp/

--- a/RHEL7-RemoteExecution/Dockerfile
+++ b/RHEL7-RemoteExecution/Dockerfile
@@ -5,7 +5,7 @@ ENV HOME /root
 WORKDIR /root
 
 RUN yum install -y openssh-server
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 ADD startup.sh /tmp/
 RUN chmod +x /tmp/startup.sh

--- a/RHEL7/Dockerfile
+++ b/RHEL7/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 ADD startup.sh /tmp/
 RUN chmod +x /tmp/startup.sh

--- a/RHEL72/Dockerfile
+++ b/RHEL72/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 ADD startup.sh /tmp/
 RUN chmod +x /tmp/startup.sh
 ADD hostname-3.13-3.el7.x86_64.rpm /tmp/

--- a/RHEL8/Dockerfile
+++ b/RHEL8/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python3.6/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 RUN echo -e "\nexport LC_ALL=C\nexport LANG=C\n" >> .bashrc
 ADD startup.sh /tmp/

--- a/SLES11/Dockerfile
+++ b/SLES11/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.6/site-packages/rhsm/config.py
 ADD startup.sh /tmp/
 ADD install-tools.sh /tmp/
 RUN chmod +x /tmp/startup.sh

--- a/SLES11sp4/Dockerfile
+++ b/SLES11sp4/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.6/site-packages/rhsm/config.py
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 ADD startup.sh /tmp/
 ADD install-tools.sh /tmp/

--- a/SLES12/Dockerfile
+++ b/SLES12/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
 ADD startup.sh /tmp/
 ADD install-tools.sh /tmp/
 RUN chmod +x /tmp/startup.sh

--- a/SLES12sp3/Dockerfile
+++ b/SLES12sp3/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 ADD startup.sh /tmp/
 ADD install-tools.sh /tmp/

--- a/SLES12sp4/Dockerfile
+++ b/SLES12sp4/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 ADD startup.sh /tmp/
 ADD install-tools.sh /tmp/

--- a/SLES15sp1/Dockerfile
+++ b/SLES15sp1/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER https://github.com/JacobCallahan
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 ADD startup.sh /tmp/
 ADD install-tools.sh /tmp/

--- a/UBI7/Dockerfile
+++ b/UBI7/Dockerfile
@@ -5,7 +5,7 @@ LABEL broker_compatible="True"
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python2.7/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 
 # add and process the external resources

--- a/UBI8/Dockerfile
+++ b/UBI8/Dockerfile
@@ -5,7 +5,7 @@ LABEL broker_compatible="True"
 ENV HOME /root
 WORKDIR /root
 
-RUN sed -i -e 's/os.path.exists(HOST_CONFIG_DIR)/False/g' /usr/lib64/python3.6/site-packages/rhsm/config.py
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 
 # add and process the external resources

--- a/UBI9/Dockerfile
+++ b/UBI9/Dockerfile
@@ -6,6 +6,7 @@ ENV HOME /root
 ENV SMDEV_CONTAINER_OFF True
 WORKDIR /root
 
+RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host
 RUN echo "{\"virt.host_type\": \"Not Applicable\", \"virt.is_guest\": \"False\"}" > /etc/rhsm/facts/custom.facts
 
 # add and process the external resources


### PR DESCRIPTION
The container images are supposed to behave as "real systems" (rather than containers). Because of historical/business reasons, subscription-manager tries to detect whether it is run within a container, and disables itself in that case. Before RHEL 9, this is done only by checking for `/etc/rhsm-host`, which is a symlink pointing to `/run/secrets/rhsm` where a docker plugin, or podman configuration, uses to mount the subscription-manager bits from the host. In RHEL 9, subscription-manager also checks for the well-known files of docker or podman as part of this container detection.

The ways done to avoid this situation so far have been the following:
- hot-patch the subscription-manager to not check `/etc/rhsm-host` at all; this is super-unsupported in any way and form, and prone to break at any time without any pre-advice
- in RHEL 9, subscription-manager uses an internal environment variable called `SMDEV_CONTAINER_OFF` to disable the container detection: this variable has always been meant to be internal for development, and unfortunately it got widespread with no feedback to the subscription-manager team...

Hence, simplify the situation a bit:
- remove the hot-patching from SUSE images: those container images definitely do not ship with /etc/rhsm-host, so there is nothing to fix
- replace the hot-patching with the removal of the `/etc/rhsm-host` & `/etc/pki/entitlement-host` symlinks, so preventing subscription-manager to notice bits for it mounted in `/run/secrets/rhsm`
- keep the `SMDEV_CONTAINER_OFF` hack in RHEL 9 for now: the subscription-manager team is working to make the registration of containers easier in newer versions, so this is still needed for now

This hopefully should keep things working as previously expected with no behaviour change.