### PR TITLE
Drop SMDEV_CONTAINER_OFF from ubi9

### DIFF
--- a/UBI9/Dockerfile
+++ b/UBI9/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER https://github.com/JacobCallahan
 LABEL broker_compatible="True"
 
 ENV HOME /root
-ENV SMDEV_CONTAINER_OFF True
 WORKDIR /root
 
 RUN rm -f /etc/rhsm-host /etc/pki/entitlement-host


### PR DESCRIPTION
The internal `SMDEV_CONTAINER_OFF` environment variable was originally needed because of the more strict container detection in RHEL 9.0. Starting from RHEL 9.3, subscription-manager has a more relaxed container detection, and `SMDEV_CONTAINER_OFF` is no more available.

Assuming only the latest ubi9 is supported, then drop the old hack that is no more needed now.

Followup of commit d344e077f2673567bc31a8de9730144c7a431899.