### PR TITLE
Disable ubi repos

### DIFF
--- a/UBI7-init/Dockerfile
+++ b/UBI7-init/Dockerfile
@@ -22,7 +22,8 @@ RUN chmod +x setup_scripts/*.sh
 RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
 WORKDIR /root
 
-RUN yum clean all
+RUN sed -i 's/enabled = 1/enabled = 0/g' /etc/yum.repos.d/ubi.repo
+RUN yum clean all || true
 
 EXPOSE 22
 

--- a/UBI7/Dockerfile
+++ b/UBI7/Dockerfile
@@ -17,6 +17,9 @@ RUN chmod +x *.sh setup_scripts/*.sh
 RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
 WORKDIR /root
 
+RUN sed -i 's/enabled = 1/enabled = 0/g' /etc/yum.repos.d/ubi.repo
+RUN yum clean all || true
+
 EXPOSE 22
 
 CMD /tmp/startup.sh

--- a/UBI8-init/Dockerfile
+++ b/UBI8-init/Dockerfile
@@ -22,6 +22,7 @@ RUN chmod +x setup_scripts/*.sh
 RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
 WORKDIR /root
 
+RUN sed -i 's/enabled = 1/enabled = 0/g' /etc/yum.repos.d/ubi.repo
 RUN dnf clean all
 
 EXPOSE 22

--- a/UBI8/Dockerfile
+++ b/UBI8/Dockerfile
@@ -17,6 +17,9 @@ RUN chmod +x *.sh setup_scripts/*.sh
 RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
 WORKDIR /root
 
+RUN sed -i 's/enabled = 1/enabled = 0/g' /etc/yum.repos.d/ubi.repo
+RUN dnf clean all
+
 EXPOSE 22
 
 CMD /tmp/startup.sh

--- a/UBI9-init/Dockerfile
+++ b/UBI9-init/Dockerfile
@@ -22,6 +22,7 @@ RUN chmod +x setup_scripts/*.sh
 RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
 WORKDIR /root
 
+RUN sed -i 's/enabled = 1/enabled = 0/g' /etc/yum.repos.d/ubi.repo
 RUN dnf clean all
 
 EXPOSE 22

--- a/UBI9/Dockerfile
+++ b/UBI9/Dockerfile
@@ -17,6 +17,9 @@ RUN chmod +x *.sh setup_scripts/*.sh
 RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
 WORKDIR /root
 
+RUN sed -i 's/enabled = 1/enabled = 0/g' /etc/yum.repos.d/ubi.repo
+RUN dnf clean all
+
 EXPOSE 22
 
 CMD /tmp/startup.sh


### PR DESCRIPTION
Having these enabled by default has resulted in undesired behavior in some test scenarios. Instead of just deleting the files, we'll disable the repos by default on image build.