### PR TITLE
Updates to build-and-push.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 flood.log
 container.log
+/resources/
+/setup_scripts/

--- a/UBI7-init/setup_scripts/01_sshd.sh
+++ b/UBI7-init/setup_scripts/01_sshd.sh
@@ -1,4 +1,5 @@
 yum -y install openssh-server
+mkdir -p /etc/ssh/sshd_config.d
 cat <<EOT >> /etc/ssh/sshd_config.d/99-redhat.conf
 PermitRootLogin yes
 

--- a/UBI8-init/setup_scripts/01_sshd.sh
+++ b/UBI8-init/setup_scripts/01_sshd.sh
@@ -1,4 +1,5 @@
 dnf -y install openssh-server
+mkdir -p /etc/ssh/sshd_config.d
 cat <<EOT >> /etc/ssh/sshd_config.d/99-redhat.conf
 PermitRootLogin yes
 

--- a/UBI9-init/setup_scripts/01_sshd.sh
+++ b/UBI9-init/setup_scripts/01_sshd.sh
@@ -1,4 +1,5 @@
 dnf -y install openssh-server
+mkdir -p /etc/ssh/sshd_config.d
 cat <<EOT >> /etc/ssh/sshd_config.d/99-redhat.conf
 PermitRootLogin yes
 


### PR DESCRIPTION
Updates to `build-and-push.sh`:

- Add error checking for the build targets/folders:
```
# Error if no targets specified:
$ sh build-and-push.sh 
No build targets specified. Exiting.

# Skip any targets that do not exist as directories in the repo:
$ sh build-and-push.sh bad_target UBI9
[...]
Target bad_target not found. Skipping.
[...]
Successfully tagged localhost/ubi9:latest
221751738394d6b26a4c0ba277b01a0ddabd144e1e43c1db97fda57e44019b3d
```

- Add the `REPO_DIR` environment variable, to override the default git repo directory `~/content-host-d`, and add a check that the directory exists:
```
$ sh build-and-push.sh UBI9
Directory /home/tpapaioa/content-host-d could not be found. Exiting.

$ REPO_DIR=~/git/content-host-d sh build-and-push.sh UBI9
[...]
Successfully tagged localhost/ubi9:latest
221751738394d6b26a4c0ba277b01a0ddabd144e1e43c1db97fda57e44019b3d
```

- Add the `ROOT_PASSWORD` environment variable, to override the default root password `change-me` (used only by the `UBI*-init` images):

```
$ ROOT_PASSWD="my_password" sh build-and-push.sh UBI9-init
[...]
Successfully tagged localhost/ubi9-init:latest
aa94051c5a985450ab378e6fe75b77db6f0b5ed48c53d055c19ddb099d75f15e

$ podman run -d aa94051c5a985450ab378e6fe75b77db6f0b5ed48c53d055c19ddb099d75f15e
cbaca0706bba0ec3c2352a8ea43f667795a4f96f05e5d210386d054b36a6bb0d

$ podman run -d aa94051c5a985450ab378e6fe75b77db6f0b5ed48c53d055c19ddb099d75f15e
cbaca0706bba0ec3c2352a8ea43f667795a4f96f05e5d210386d054b36a6bb0d

$ podman exec -it cbaca0706bba0ec3c2352a8ea43f667795a4f96f05e5d210386d054b36a6bb0d login
cbaca0706bba login: root
Password: my_password 
#
```

- Add the top-level `resources` and `setup_scripts` directories to `.gitignore`. Any user-provided resources and scripts in these directories get copied over to each build target's directory (e.g., `UBI9/resources/` and `UBI9/setup_scripts/`) during the build, so I've also added a `git clean -f` to the script to clear out any old user-provided resources or scripts in the target directories, before copying over the latest files from the top-level directories.

- Add `mkdir -p /etc/ssh/sshd_config.d` to the `UBI*-init/setup_scripts/01_sshd.sh`, to avoid potential `No such file or directory` errors like this:

```
$ sh build-and-push.sh UBI8-init
[...]
Installed:
  openssh-8.0p1-25.el8_10.x86_64      openssh-server-8.0p1-25.el8_10.x86_64     

Complete!
setup_scripts/01_sshd.sh: line 2: /etc/ssh/sshd_config.d/99-redhat.conf: No such file or directory
--> af22d168e55c
STEP 16/19: WORKDIR /root
--> 1a00d036fcc6
[...]
```