### PR TITLE
Use HTTPS_PROXY in build-and-push.sh

### DIFF
--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -47,5 +47,8 @@ do
     # Use cgroup v1 for UBI7-init images.
 	[[ ${var,,} == ubi7-init ]] && BUILD_CMD+=" --annotation 'run.oci.systemd.force_cgroup_v1=/sys/fs/cgroup'"
 
+    # Use proxy if set.
+    [[ -v HTTPS_PROXY ]] && BUILD_CMD+=" --env=HTTPS_PROXY=${HTTPS_PROXY} --net host"
+
     eval ${BUILD_CMD}
 done


### PR DESCRIPTION
Use `HTTPS_PROXY` when building images in `build-and-push.sh`.

```
# bash /root/content-host-d/build-and-push.sh UBI10
STEP 1/15: FROM registry.access.redhat.com/ubi10/ubi
[...]
STEP 9/15: RUN chmod +x *.sh setup_scripts/*.sh
--> Using cache 1ed00918730c9100587efe44ddea14a80716def4211c72102caaa9274751e19a
--> 1ed00918730c
STEP 10/15: RUN for i in `ls setup_scripts/*.sh`; do bash $i; done
[...]
Red Hat Universal Base Image 10 (RPMs) - BaseOS 0.0  B/s |   0  B     00:40    
Errors during downloading metadata for repository 'ubi-10-for-x86_64-baseos-rpms':
  - Curl error (6): Could not resolve hostname for https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/repodata/repomd.xml [Could not resolve host: cdn-ubi.redhat.com]
Error: Failed to download metadata for repo 'ubi-10-for-x86_64-baseos-rpms': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried

# HTTPS_PROXY='http://proxy.example.com:3128' bash /root/content-host-d/build-and-push.sh UBI10
STEP 1/16: FROM registry.access.redhat.com/ubi10/ubi
[...]
Successfully tagged localhost/ubi10:latest
1a4797083dfb562074516e721a79d7f7d18fa169cd69bccb88575fabbfcc7cdd
```
